### PR TITLE
Add ESP32 def instance & configuration for GR_LYCHEE

### DIFF
--- a/ESP32Interface.cpp
+++ b/ESP32Interface.cpp
@@ -18,6 +18,21 @@
 #include "ESP32Interface.h"
 
 // ESP32Interface implementation
+ESP32Interface::ESP32Interface() :
+    ESP32Stack(MBED_CONF_ESP32_WIFI_EN, MBED_CONF_ESP32_WIFI_IO0, MBED_CONF_ESP32_WIFI_TX, MBED_CONF_ESP32_WIFI_RX, MBED_CONF_ESP32_WIFI_DEBUG, MBED_CONF_ESP32_WIFI_RTS, MBED_CONF_ESP32_WIFI_CTS, MBED_CONF_ESP32_WIFI_BAUDRATE),
+     _dhcp(true),
+    _ap_ssid(),
+    _ap_pass(),
+    _ap_sec(NSAPI_SECURITY_NONE),
+    _ip_address(),
+    _netmask(),
+    _gateway(),
+    _connection_status(NSAPI_STATUS_DISCONNECTED),
+    _connection_status_cb(NULL)
+{
+    _esp->attach_wifi_status(callback(this, &ESP32Interface::wifi_status_cb));
+}
+
 ESP32Interface::ESP32Interface(PinName en, PinName io0, PinName tx, PinName rx, bool debug,
     PinName rts, PinName cts, int baudrate) :
     ESP32Stack(en, io0, tx, rx, debug, rts, cts, baudrate),
@@ -194,4 +209,13 @@ void ESP32Interface::wifi_status_cb(int8_t wifi_status)
             break;
     }
 }
+
+#if MBED_CONF_ESP32_PROVIDE_DEFAULT
+
+WiFiInterface *WiFiInterface::get_default_instance() {
+    static ESP32Interface esp32;
+    return &esp32;
+}
+
+#endif
 

--- a/ESP32Interface.h
+++ b/ESP32Interface.h
@@ -27,6 +27,11 @@ class ESP32Interface : public ESP32Stack, public WiFiInterface
 {
 public:
     /** ESP32Interface lifetime
+     * Configuration defined in mbed_lib.json
+     */
+    ESP32Interface();
+
+    /** ESP32Interface lifetime
      * @param en        EN pin  (If not used this pin, please set "NC")
      * @param io0       IO0 pin (If not used this pin, please set "NC")
      * @param tx        TX pin

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,50 @@
+{
+    "name": "esp32",
+    "config": {
+        "wifi-en": {
+            "help": "Enable pin",
+            "value": "NC"
+        },
+        "wifi-io0": {
+            "help": "IO0 pin",
+            "value": "NC"
+        },
+        "wifi-tx": {
+            "help": "Serial TX pin",
+            "value": "NC"
+        },
+        "wifi-rx": {
+            "help": "Serial RX pin",
+            "value": "NC"
+        },
+        "wifi-debug": {
+            "help": "Enable debugging",
+            "value": false
+        },
+        "wifi-rts": {
+            "help": "Serial RTS pin",
+            "value": "NC"
+        },
+        "wifi-cts": {
+            "help": "Serial CTS pin",
+            "value": "NC"
+        },
+        "wifi-baudrate": {
+            "help": "Serial baudrate",
+            "value": "230400"
+        },
+        "provide-default": {
+            "help": "Provide default WifiInterface. [true/false]",
+            "value": false
+        }
+    },
+    "target_overrides": {
+        "GR_LYCHEE": {
+            "esp32.wifi-en" : "P5_3",
+            "esp32.wifi-io0": "P3_14",
+            "esp32.wifi-tx" : "P7_1",
+            "esp32.wifi-rx" : "P0_1",
+            "esp32.provide-default": true
+        }
+     }
+}


### PR DESCRIPTION
Find here an enhancement to add a default network interface for the ESP32 wifi driver and the GR_LYCHEE platform.

The simplifies the setup, improves UX for users, and makes it possible to work with automated tests - see [here](https://github.com/ARMmbed/simple-mbed-cloud-client#testing).

Example of usage (main.cpp):

```
#include "mbed.h"

int main(void) {
    NetworkInterface *net = NetworkInterface::get_default_instance();
    nsapi_error_t net_status = net->connect();
}
```

@d-kato @toyowata
Please let me know if you have any comments/questions. Thanks!
